### PR TITLE
log file is closed at the end of screen.c

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -29,7 +29,6 @@ int main(void)
 		/* TODO: Temporary exit condition */
 		if (strcmp(args, "exit\n") == 0)
 		{
-			close_log_file();
 			should_run = 0;
 		}
 
@@ -38,6 +37,7 @@ int main(void)
 	
 	log_debug("Freeing args...\n");
 	free(args);
+	close_log_file();
 
 	return 0;
 }


### PR DESCRIPTION
Move log file close command to the end of screen.c to allow memory logs to be written in the log file